### PR TITLE
seo: refresh sitemap lastmod signals + bump 5 unindexed posts

### DIFF
--- a/content/blog/freelancer-vs-agency-software-development.md
+++ b/content/blog/freelancer-vs-agency-software-development.md
@@ -8,6 +8,7 @@ coverImg: /images/blog/freelancer-vs-agency.webp
 coverImgAlt: "Freelancer vs Agency for software development — an honest comparison of trade-offs"
 published: true
 createdAt: "2026-04-15"
+updatedAt: "2026-04-20"
 keywords:
   - freelancer vs agency software development
   - freelancer vs development agency

--- a/content/blog/mvp-development-cost.md
+++ b/content/blog/mvp-development-cost.md
@@ -10,6 +10,7 @@ published: true
 toc: true
 readingTime: "18 min read"
 createdAt: "2026-04-03"
+updatedAt: "2026-04-20"
 keywords:
   - how much does MVP development cost
   - MVP development cost 2026

--- a/content/blog/mvp-development-process.md
+++ b/content/blog/mvp-development-process.md
@@ -10,6 +10,7 @@ published: true
 toc: true
 readingTime: "16 min read"
 createdAt: "2026-04-09"
+updatedAt: "2026-04-20"
 keywords:
   - mvp development process
   - mvp development timeline

--- a/content/blog/staff-augmentation-vs-outsourcing.md
+++ b/content/blog/staff-augmentation-vs-outsourcing.md
@@ -10,6 +10,7 @@ published: true
 toc: true
 readingTime: "15 min read"
 createdAt: "2026-04-05"
+updatedAt: "2026-04-20"
 keywords:
   - staff augmentation vs outsourcing
   - staff augmentation vs IT outsourcing

--- a/content/blog/understanding-difference-between-ruby-class-method-and-instance-method.md
+++ b/content/blog/understanding-difference-between-ruby-class-method-and-instance-method.md
@@ -7,6 +7,7 @@ coverImg: /images/blog/ruby-class-instance.webp
 coverImgAlt: Cover image for the blog, "Understanding the difference between Ruby class method and instance method"
 published: true
 createdAt: "2022-10-03"
+updatedAt: "2026-04-20"
 ---
 
 Though this is a very simple concept. In my early days of using Ruby, I was always confused about which one to use when and why. I came up with the following way to identify if a method should be a class method or an instance method. I hope this will help you also clear the confusion.

--- a/server/api/__sitemap__/urls.ts
+++ b/server/api/__sitemap__/urls.ts
@@ -8,8 +8,12 @@ const withSlash = (path: string): string =>
   path === '/' || path.endsWith('/') ? path : `${path}/`
 
 export default defineSitemapEventHandler(async (event) => {
-  // Static pages
-  const lastmod = '2026-04-09T00:00:00.000Z'
+  // Static pages — lastmod resolves at build time (`nuxi generate`), so each
+  // deploy advertises a fresh lastmod across every static URL. This is the
+  // honest signal: "the rendered bytes changed at deploy time." Without it
+  // the sitemap stayed frozen at a hardcoded date and Google lost the signal
+  // that pages had refreshed.
+  const lastmod = new Date().toISOString()
 
   const staticPaths = [
     // Homepage
@@ -65,14 +69,19 @@ export default defineSitemapEventHandler(async (event) => {
 
   const staticUrls = staticPaths.map((p) => ({ ...p, loc: withSlash(p.loc), lastmod }))
 
-  // Dynamic blog post URLs from Nuxt Content
+  // Dynamic blog post URLs from Nuxt Content. Prefer `updatedAt` over
+  // `createdAt` so content refreshes surface in the sitemap — otherwise
+  // rewriting a post would never tell Google to re-crawl.
   const blogPosts = await serverQueryContent(event, 'blog').find()
-  const blogUrls = blogPosts.map((post) => ({
-    loc: withSlash(post._path),
-    changefreq: 'monthly' as const,
-    priority: 0.6,
-    ...(post.createdAt ? { lastmod: new Date(post.createdAt).toISOString() } : {}),
-  }))
+  const blogUrls = blogPosts.map((post) => {
+    const modDate = post.updatedAt || post.createdAt
+    return {
+      loc: withSlash(post._path),
+      changefreq: 'monthly' as const,
+      priority: 0.6,
+      ...(modDate ? { lastmod: new Date(modDate).toISOString() } : {}),
+    }
+  })
 
   return [...staticUrls, ...blogUrls]
 })


### PR DESCRIPTION
GSC inspection shows 6 pages stuck in "Discovered – currently not indexed" with last_crawl_time=null — Google has never crawled them. Root cause is not content quality (5 of 6 are 1,800–2,500-word posts); it's that the sitemap is telling Google nothing has changed:

  1. Static-page lastmod was hardcoded to 2026-04-09 and identical across every URL. Sitemap froze in time regardless of deploys.
  2. Blog-post lastmod derived from createdAt, so content rewrites never surfaced as freshness signals.
  3. 5 of the 6 stuck posts have no updatedAt frontmatter at all, so even a future switch to updatedAt wouldn't help them without a refresh.

Fixes:
  - Static lastmod resolves at build time (`nuxi generate`) so each deploy advertises a fresh lastmod across every static URL.
  - Blog lastmod prefers updatedAt over createdAt, falling back cleanly.
  - Add updatedAt: "2026-04-20" to the 5 stuck blog posts so the next sitemap publishes them as freshly modified.

Expected: Google re-crawls these URLs within days once the sitemap republishes with current lastmod values. The /guides/mvp-development/ page (Vue, not content) inherits the fresh static lastmod automatically.