### PR TITLE
seo: add IndexNow key file for Bing/Yandex submission

### DIFF
--- a/public/78ffe3af72f73aea79f6803a451cb10e.txt
+++ b/public/78ffe3af72f73aea79f6803a451cb10e.txt
@@ -1,0 +1,1 @@
+78ffe3af72f73aea79f6803a451cb10e


### PR DESCRIPTION
IndexNow requires hosting a key file at the domain root so the endpoint can verify ownership before accepting URL submissions. This file is served by Nuxt's `public/` → root mapping, so
https://acornglobus.com/78ffe3af72f73aea79f6803a451cb10e.txt returns exactly those 32 bytes with no trailing whitespace.

Paired with the index_notify harness in selflearningai, which POSTs the stuck-URL list to https://api.indexnow.org/indexnow after deploys. The key value is deliberately random (not a secret — the protocol relies on "if you can serve this file, you control the domain").

Google does NOT honor IndexNow; this only covers Bing and Yandex. The same harness submits the sitemap to Google via Search Console's sitemaps.submit endpoint separately.