### PR TITLE
analytics: wire GA4 events via GTM dataLayer (8 events, typed)

### DIFF
--- a/components/lead-capture/SmartCta.vue
+++ b/components/lead-capture/SmartCta.vue
@@ -11,7 +11,7 @@
           {{ text }}
         </p>
         <div class="smart-cta__actions">
-          <NuxtLink :to="ctaLink" class="smart-cta__button">
+          <NuxtLink :to="ctaLink" class="smart-cta__button" @click="handleCtaClick">
             {{ ctaLabel }}
             <ArrowRight class="smart-cta__button-icon" />
           </NuxtLink>
@@ -30,6 +30,11 @@
 
 <script setup>
 import { ArrowRight, X } from 'lucide-vue-next'
+import { useTrack } from '~/composables/useTrack'
+
+const track = useTrack()
+const route = useRoute()
+let impressionFired = false
 
 const props = defineProps({
   text: {
@@ -74,7 +79,16 @@ onMounted(() => {
     const scrollHeight = document.documentElement.scrollHeight - window.innerHeight
     if (scrollHeight <= 0) return
     const scrollPercent = window.scrollY / scrollHeight
-    visible.value = scrollPercent >= props.scrollThreshold
+    const shouldShow = scrollPercent >= props.scrollThreshold
+    if (shouldShow && !visible.value && !impressionFired) {
+      impressionFired = true
+      track({
+        event: 'smart_cta_impression',
+        source_page: route.fullPath,
+        cta_variant: props.dismissKey,
+      })
+    }
+    visible.value = shouldShow
   }
 
   window.addEventListener('scroll', handleScroll, { passive: true })
@@ -87,6 +101,19 @@ onMounted(() => {
 const dismiss = () => {
   dismissed.value = true
   localStorage.setItem(`ag_cta_dismissed_${props.dismissKey}`, String(Date.now()))
+  track({
+    event: 'smart_cta_dismiss',
+    source_page: route.fullPath,
+    cta_variant: props.dismissKey,
+  })
+}
+
+const handleCtaClick = () => {
+  track({
+    event: 'smart_cta_click',
+    source_page: route.fullPath,
+    cta_variant: props.dismissKey,
+  })
 }
 </script>
 

--- a/composables/useTrack.ts
+++ b/composables/useTrack.ts
@@ -1,0 +1,39 @@
+// useTrack — typed wrapper around window.dataLayer.push for GA4 via GTM.
+//
+// Why a union type: misspelling an event name or shipping an event with the
+// wrong parameter shape silently poisons reports. The discriminated union
+// below catches those at compile time. To add a new event: extend TrackEvent,
+// update docs/analytics-events.md, then configure a GA4 Event tag in GTM
+// that listens for the same `event` name.
+//
+// The taxonomy itself is documented in docs/analytics-events.md — keep the
+// two in sync.
+
+type SocialPlatform = 'linkedin' | 'x' | 'github'
+type CtaVariant = 'sidebar' | 'body' | 'footer' | 'floating' | 'inline' | 'header'
+
+export type TrackEvent =
+  // ── Primary conversions ────────────────────────────────────────────────
+  | { event: 'contact_form_submit'; form_location: 'contact_page'; services: string[] }
+  | { event: 'click_book_call'; source_page: string; cta_variant?: CtaVariant }
+  | { event: 'click_email'; source_page: string; cta_variant?: CtaVariant; email?: string }
+  // ── Secondary (diagnostic) ─────────────────────────────────────────────
+  | { event: 'form_start'; form_location: string }
+  | { event: 'smart_cta_impression'; source_page: string; cta_variant: string }
+  | { event: 'smart_cta_click'; source_page: string; cta_variant: string }
+  | { event: 'smart_cta_dismiss'; source_page: string; cta_variant: string }
+  | { event: 'outbound_social_click'; source_page: string; platform: SocialPlatform; url: string }
+
+declare global {
+  interface Window {
+    dataLayer?: Array<Record<string, unknown>>
+  }
+}
+
+export function useTrack() {
+  return (e: TrackEvent) => {
+    if (typeof window === 'undefined') return
+    window.dataLayer = window.dataLayer || []
+    window.dataLayer.push(e as unknown as Record<string, unknown>)
+  }
+}

--- a/docs/analytics-events.md
+++ b/docs/analytics-events.md
@@ -1,0 +1,54 @@
+# Analytics event taxonomy
+
+Source of truth for every event pushed to `window.dataLayer` by this codebase. When GTM is configured, each event below maps to a GA4 Event tag that forwards it to the property.
+
+Changing this list without updating `composables/useTrack.ts` (the typed union) or the GTM tags will silently drop data — keep all three in sync.
+
+## Primary conversions
+
+Mark each of these as a conversion in **GA4 → Admin → Events → "Mark as conversion"** toggle.
+
+| event_name | fires when | parameters | wired in |
+|---|---|---|---|
+| `contact_form_submit` | POST to Formester returns success | `form_location: 'contact_page'`, `services: string[]` | `pages/contact.vue` — inside `handleSubmit` after `await axios.post` resolves |
+| `click_book_call` | click on a Google Calendar link (`calendar.app.google/...`) anywhere on the site | `source_page: string`, `cta_variant?: 'sidebar' \| 'body' \| 'footer' \| 'floating' \| 'inline' \| 'header'` | `plugins/analytics-delegated.client.ts` — delegated listener |
+| `click_email` | click on any `mailto:business@acornglobus.com` anywhere on the site | `source_page: string`, `cta_variant?: ...`, `email: string` | `plugins/analytics-delegated.client.ts` — delegated listener |
+
+## Secondary (diagnostic) events
+
+These are engagement signals. Do NOT mark as conversions — they inflate the number and dilute the metric.
+
+| event_name | fires when | parameters | wired in |
+|---|---|---|---|
+| `form_start` | first input focused on the contact form | `form_location: string` | `pages/contact.vue` — `@focusin.once` on the `<form>` |
+| `smart_cta_impression` | SmartCta floating bar becomes visible (scroll ≥ 60 %) | `source_page: string`, `cta_variant: string` (= `dismissKey` prop) | `components/lead-capture/SmartCta.vue` — inside scroll handler, once per mount |
+| `smart_cta_click` | click on the SmartCta button | same | `SmartCta.vue` — `@click` on the NuxtLink |
+| `smart_cta_dismiss` | click on the SmartCta X button | same | `SmartCta.vue` — `dismiss()` |
+| `outbound_social_click` | click on LinkedIn / X / GitHub link (only our own accounts) | `source_page: string`, `platform: 'linkedin' \| 'x' \| 'github'`, `url: string` | `plugins/analytics-delegated.client.ts` — delegated listener |
+
+## Already covered by GA4 Enhanced Measurement
+
+Nothing to wire in code — GA4 auto-tracks these as long as Enhanced Measurement is on for the Data Stream.
+
+- `page_view` — every route navigation
+- `scroll` — 90% of page depth reached
+- `click` — outbound clicks (to non-acornglobus domains)
+- `file_download` — click on links ending in common file extensions
+- `video_start` / `video_progress` / `video_complete` — YouTube / Vimeo embeds
+
+> **Disabled deliberately:** `form_start` / `form_submit` under Enhanced Measurement. The built-in detection is heuristic-based and misfires on the Nuxt SPA. Our explicit events above replace it cleanly.
+
+## Adding a new event
+
+1. Extend the `TrackEvent` union in `composables/useTrack.ts` with the new discriminant + parameter shape
+2. Call `useTrack()` from the component that owns the action
+3. Add a row to the table above
+4. Create a matching GA4 Event tag in GTM — see `projects/marketing-acorn/gtm-runbook.md` in the selflearningai repo for the click-by-click steps
+5. If it's a conversion, mark it in GA4 → Admin → Events
+
+## Testing in GTM Preview mode
+
+1. In the GTM UI, click **Preview** (top right) → paste `https://acornglobus.com/`
+2. In the Tag Assistant window that opens, navigate the site and trigger the actions above
+3. The dataLayer panel should show each event with its parameters
+4. GA4 DebugView (GA4 → Admin → DebugView) will show the event arriving ~30 s later if Preview mode is active

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -82,7 +82,7 @@
           <!-- LEFT: Contact Form -->
           <div class="contact-form-section">
             <h2>Tell us what you're building</h2>
-            <form @submit.prevent="handleSubmit">
+            <form @submit.prevent="handleSubmit" @focusin.once="handleFormStart">
               <div class="form-group">
                 <label for="full-name">Full Name <span class="required">*</span></label>
                 <input type="text" id="full-name" v-model="formData.fullName" class="form-input" placeholder="John Doe" required>
@@ -146,7 +146,7 @@
           </div>
 
           <!-- RIGHT: Sidebar -->
-          <div class="contact-sidebar">
+          <div class="contact-sidebar" data-cta-variant="sidebar">
             <div class="sidebar-section">
               <h3>Quick Actions</h3>
               <a href="https://calendar.app.google/gbT42VeCDd7ioXh79" target="_blank" rel="noopener noreferrer" class="sidebar-link">
@@ -214,6 +214,9 @@
 <script setup>
 import { ref } from 'vue'
 import axios from 'axios'
+import { useTrack } from '~/composables/useTrack'
+
+const track = useTrack()
 
 definePageMeta({ layout: 'default' })
 
@@ -247,6 +250,10 @@ const formData = ref({
 const isSubmitting = ref(false)
 const submitSuccess = ref(false)
 
+const handleFormStart = () => {
+  track({ event: 'form_start', form_location: 'contact_page' })
+}
+
 const faqs = [
   { question: 'What services does AcornGlobus offer?', answer: 'We offer four core services: Resource Augmentation (dedicated engineers who embed with your team), MVP Development (ship a real product in 8-12 weeks), Full Project Delivery (end-to-end product engineering), and Maintenance & Support (ongoing care from the team that built it).' },
   { question: 'How quickly can you start on a project?', answer: 'For resource augmentation, we can typically match engineers and begin within 1-2 weeks. For MVP and full project delivery, we start with a discovery phase within the first week of engagement.' },
@@ -272,6 +279,11 @@ const handleSubmit = async () => {
       message: formData.value.message
     }
     await axios.post(submissionUrl, submissionData)
+    track({
+      event: 'contact_form_submit',
+      form_location: 'contact_page',
+      services: [...formData.value.services],
+    })
     isSubmitting.value = false
     submitSuccess.value = true
     setTimeout(() => {

--- a/plugins/analytics-delegated.client.ts
+++ b/plugins/analytics-delegated.client.ts
@@ -1,0 +1,85 @@
+// Global click delegation for analytics events that fire from many spots.
+// Listening on document capture lets us avoid editing 11+ mailto anchors and
+// 3 social links across 9 files — a stray new link gets tracked automatically
+// without remembering to wire it up.
+//
+// Handles three primary-conversion / secondary events:
+//   click_email          → mailto:business@acornglobus.com anywhere
+//   click_book_call      → https://calendar.app.google/... anywhere
+//   outbound_social_click → linkedin.com/company/acornglobus, x.com/AcornGlobus,
+//                           github.com/acorn-globus (only our own accounts)
+
+import { useTrack } from '~/composables/useTrack'
+
+const EMAIL_ADDRESS = 'business@acornglobus.com'
+const CALENDAR_HOST = 'calendar.app.google'
+
+type SocialMatch = { platform: 'linkedin' | 'x' | 'github'; urlFragment: string }
+const SOCIAL_MATCHERS: SocialMatch[] = [
+  { platform: 'linkedin', urlFragment: 'linkedin.com/company/acornglobus' },
+  { platform: 'x', urlFragment: 'x.com/AcornGlobus' },
+  { platform: 'github', urlFragment: 'github.com/acorn-globus' },
+]
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const track = useTrack()
+
+  const onClick = (e: MouseEvent) => {
+    // Walk up the DOM because clicks often land on inner text, icon, or span.
+    const anchor = (e.target as Element | null)?.closest?.('a')
+    if (!anchor) return
+    const href = anchor.getAttribute('href') || ''
+    if (!href) return
+
+    const route = nuxtApp.$router?.currentRoute?.value
+    const sourcePage = route?.fullPath || (typeof window !== 'undefined' ? window.location.pathname : '')
+
+    // Heuristic for variant: check which landmark the anchor sits in.
+    const variant: 'sidebar' | 'body' | 'footer' | 'header' | 'floating' | 'inline' = (() => {
+      if (anchor.closest('footer')) return 'footer'
+      if (anchor.closest('header, nav[role="navigation"]')) return 'header'
+      if (anchor.closest('aside, .sidebar, [data-cta-variant="sidebar"]')) return 'sidebar'
+      if (anchor.closest('[data-cta-variant="floating"]')) return 'floating'
+      return 'body'
+    })()
+
+    // ── Email ───────────────────────────────────────────────────────────
+    if (href.startsWith('mailto:')) {
+      const email = href.slice('mailto:'.length).split('?')[0]
+      track({
+        event: 'click_email',
+        source_page: sourcePage,
+        cta_variant: variant,
+        email,
+      })
+      return
+    }
+
+    // ── Book-a-call (Google Calendar) ───────────────────────────────────
+    if (href.includes(CALENDAR_HOST)) {
+      track({
+        event: 'click_book_call',
+        source_page: sourcePage,
+        cta_variant: variant,
+      })
+      return
+    }
+
+    // ── Social (only our own accounts) ──────────────────────────────────
+    for (const m of SOCIAL_MATCHERS) {
+      if (href.includes(m.urlFragment)) {
+        track({
+          event: 'outbound_social_click',
+          source_page: sourcePage,
+          platform: m.platform,
+          url: href,
+        })
+        return
+      }
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    document.addEventListener('click', onClick, { capture: true, passive: true })
+  }
+})


### PR DESCRIPTION
Sets up the event taxonomy that MA-M3 (ga4_pull harness in the selflearningai repo) will report on. Three primary conversions (contact_form_submit, click_book_call, click_email) and five diagnostic events (form_start, smart_cta_impression/click/dismiss, outbound_social_click).

Pushes events via GTM dataLayer rather than direct gtag() calls — GTM is already wired in plugins/gtm.js, so GA4 tags live in the GTM UI and tracking changes don't need a redeploy.

Components:
  composables/useTrack.ts
    Typed discriminated-union over TrackEvent so misspelling an event
    name or shipping wrong-shape parameters fails at compile time
    instead of silently poisoning reports.

  plugins/analytics-delegated.client.ts
    Global click listener catches mailto:, calendar.app.google, and
    our own linkedin/x/github URLs — avoids editing 11 mailto anchors
    across 9 files and automatically covers any new links added later.
    Variant is inferred from the closest landmark element (footer,
    header, sidebar via data-cta-variant) so reports can segment by
    placement without per-link config.

  pages/contact.vue
    @focusin.once fires form_start on first input focus.
    contact_form_submit fires after the Formester POST succeeds, with
    the selected services array so we can segment by which service
    drives leads.

  components/lead-capture/SmartCta.vue
    Impression fires once per page mount when the CTA becomes visible
    (not on every scroll delta). Click + dismiss fire on interaction.
    cta_variant comes from the dismissKey prop so different SmartCta
    instances can be separately analysed.

  docs/analytics-events.md
    Source of truth for the taxonomy. Kept alongside the code so the
    next person doesn't have to grep to find what events exist.

Manual setup after merge (see projects/marketing-acorn/gtm-runbook.md in the selflearningai repo for click-by-click):
  1. In GTM, add a GA4 Configuration tag + GA4 Event tags for each of the 8 custom events
  2. In GA4, mark contact_form_submit, click_book_call, click_email as conversions
  3. In GA4, turn OFF Enhanced Measurement's built-in form interactions (heuristic-based, unreliable on Nuxt SPAs — our explicit events replace it cleanly)